### PR TITLE
Return full title in lecturers list

### DIFF
--- a/app/Http/Resources/Lecturer/LecturerResource.php
+++ b/app/Http/Resources/Lecturer/LecturerResource.php
@@ -18,7 +18,7 @@ class LecturerResource extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'surname' => $this->surname,
-            'title' => $this->title->name
+            'title' => $this->title
         ];
     }
 }

--- a/app/Http/Resources/Title/TitleResource.php
+++ b/app/Http/Resources/Title/TitleResource.php
@@ -15,6 +15,7 @@ class TitleResource extends JsonResource
     public function toArray($request)
     {
         return [
+            'id' => $this->id,
             'name' => $this->name,
             'short_name' => $this->short_name,
             'full_name' => $this->full_name,


### PR DESCRIPTION
When sending a lecturer object back to the API it expects a title_id provided. This was impossible, as in the response only a title name was provided. Now full title object is returned as a nested field